### PR TITLE
管理用商品一覧ページのバグ修正

### DIFF
--- a/app/views/admin/genres/edit.html.erb
+++ b/app/views/admin/genres/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="container" style="height: 14rem;">
+<div class="container">
  <h1>ジャンル編集</h1>
     <%= form_with model: [:admin,@genre], local: true do |f| %>
       <div>ジャンル名</div>

--- a/app/views/admin/products/index.html.erb
+++ b/app/views/admin/products/index.html.erb
@@ -1,16 +1,15 @@
 <div class="container">
   <h1 class="text-center">商品一覧</h1>
-      
-      <div class="my-3　mr-5 text-right">
+      <div class="my-3 mr-5 text-right">
         <%= link_to"商品新規登録", new_admin_product_path, class: "btn btn-outline-secondary" %>
       </div>
-      
+
         <table class="table table-sm table-striped">
           <thead>
             <tr>
               <th class="text-center"　style="width: 10%">商品ID</th>
               <th class="text-center"　style="width: 30%">商品名</th>
-              <th　class="text-center" style="width: 20%">税抜価格</th>
+              <th class="text-center" style="width: 20%">税抜価格</th>
               <th class="text-center"　style="width: 20%">ジャンル</th>
               <th class="text-center"　style="width: 20%">ステータス</th>
             </tr>
@@ -18,7 +17,7 @@
           <tbody>
     				<% @products.each do |product| %>
       				<tr>
-                <td　 class="text-center">
+                <td class="text-center">
                   <%= product.id %>
                 </td>
                 <td class="link">
@@ -26,13 +25,13 @@
                     <%= product.name %>
                   <% end %>
                 </td>
-                <td　 class="text-center">
+                <td class="text-center">
                   ¥<%= product.price.to_s(:delimited) %>
                 </td>
-                <td　 class="text-center">
+                <td class="text-center">
                   <%= product.genre.name %>
                 </td>
-                <td　 class="text-center">
+                <td class="text-center">
                   <% if product.is_active == true %>
           					<p　style="color: limegreen">販売中</p>
           				<% elsif product.is_active == false %>
@@ -43,6 +42,5 @@
             <% end %>
           </tbody>
         </table>
-    </div>
     <%= paginate @products %>
 </div>

--- a/app/views/public/homes/about.html.erb
+++ b/app/views/public/homes/about.html.erb
@@ -1,4 +1,4 @@
-<div class="container" style="height: 20rem;">
+<div class="container">
   <div class="row">
     <div class="col-md-7">
         <h1>About</h1>


### PR DESCRIPTION
* フッターの修正に伴い、高さを指定していたページの指定を解除
* 管理側の一覧ページがおかしくなっていたので修正